### PR TITLE
Add support for dispose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # fast-lru
 
 A cache module that deletes the least-recently-used items, inspired by [lru-cache](https://github.com/isaacs/node-lru-cache) and implementing [GeeksForGeeks' algorithm](http://www.geeksforgeeks.org/implement-lru-cache/)
+
+## Options
+
+When creating a new fast-LRU cache instance, you can optionally supply three separate options:
+- `getSize`: a `function` used to calculate the size of an item in the cache. The function is passed the value and the key as an argument. By default items will have a size of `1`.
+- `maximumSize`: a `number` representing the maximum size of the cache.
+- `dispose` a `function` which is called when an item is removed from the cache (either due to cache size limits or by setting a different value for a key). This function is passed both the key and value as arguments.
+
+## API
+- `has`: Given a key, returns whether or not an item is in the cache.
+- `get`: Given a key, returns the item in the cache or `undefined`.
+- `set`: Given a key and value, assigns the value to that key in the cache. Returns true if the item was successfully added to the cache, otherwise returns false.

--- a/lib/fast-lru.js
+++ b/lib/fast-lru.js
@@ -33,7 +33,10 @@ function LRU(options)
     private(this, "size", 0);
     private(this, "getSize", getSize);
     private(this, "maximumSize", maximumSize);
+    private(this, "dispose", options.dispose || noop);
 }
+
+function noop() {}
 
 function simpleSize()
 {
@@ -81,19 +84,21 @@ LRU.prototype.set = function(aKey, aValue)
 
     // Easy case, it won't make it in, and we don't have it.
     if (elementSize > maximumSize && !element)
-        return;
+        return false;
 
     var list = private(this, "list");
     var size = private(this, "size");
+    var dispose = private(this, "dispose");
 
     // Won't make it in, but we do have it.
     if (elementSize > maximumSize && !!element)
     {
         private(this, "size", size - element.size);
         remove(list, element);
+        dispose(last.key, last.value);
         unshift(private(this, "cache"), element);
 
-        return;
+        return false;
     }
 
     var appendedSize = size + elementSize;
@@ -103,6 +108,7 @@ LRU.prototype.set = function(aKey, aValue)
     {
         var reducedSize = appendedSize - element.size;
 
+        dispose(element.key, element.value);
         toFront(list, element);
         element.value = aValue;
         element.size = elementSize;
@@ -111,7 +117,7 @@ LRU.prototype.set = function(aKey, aValue)
 
         shrink(this);
 
-        return;
+        return true;
     }
 
     // Will make it in and we DON'T have it
@@ -122,6 +128,8 @@ LRU.prototype.set = function(aKey, aValue)
 
     map.set(aKey, element);
     unshift(list, element);
+
+    return true;
 }
 
 function getElement(anLRU, aKey, aValue, anElementSize)
@@ -150,6 +158,7 @@ function shrink(anLRU)
     var list = private(anLRU, "list");
     var map = private(anLRU, "map");
     var cache = private(anLRU, "cache");
+    var dispose = private(anLRU, "dispose");
 
     while (size > maximumSize && list.last)
     {
@@ -157,6 +166,7 @@ function shrink(anLRU)
 
         size -= last.size;
         remove(list, last);
+        dispose(last.key, last.value);
         map.delete(last.key);
         unshift(cache, last);
     }

--- a/lib/fast-lru.js
+++ b/lib/fast-lru.js
@@ -95,7 +95,7 @@ LRU.prototype.set = function(aKey, aValue)
     {
         private(this, "size", size - element.size);
         remove(list, element);
-        dispose(last.key, last.value);
+        dispose(element.key, element.value);
         unshift(private(this, "cache"), element);
 
         return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-lru",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A fast doubly-linked list implementation of LRU capable of handling hundreds of thousands of items quickly.",
   "main": "./lib/fast-lru",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/playgroundtheory/fast-lru.git"
+    "url": "git+https://github.com/runkit-open-source/fast-lru.git"
   },
   "keywords": [
     "lru"
@@ -16,9 +16,9 @@
   "author": "Francisco Ryan Tolmasky I",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/playgroundtheory/fast-lru/issues"
+    "url": "https://github.com/runkit-open-source/fast-lru/issues"
   },
-  "homepage": "https://github.com/playgroundtheory/fast-lru#readme",
+  "homepage": "https://github.com/runkit-open-source/fast-lru#readme",
   "devDependencies": {
     "tap": "^3.3.1"
   }


### PR DESCRIPTION
This PR adds a callback option for when items are ejected from the cache. It's the same option as slow-lru.
I also now have the `set` method for the cache return true/false if the item was added to the cache or not. e.g. if the item is too big to fit in the cache on its own then it return false. It looks like slow-lru has done that since the beginning.

This PR bumps the version number to 3.1.0, updates the repo location in the package.json and adds a little more detail to the readme. 